### PR TITLE
Replace individual email addresses with alerts@measurementlab.net

### DIFF
--- a/mlab-ssh-outage.sh
+++ b/mlab-ssh-outage.sh
@@ -284,7 +284,7 @@ perform_the_reboot() {
 ########################################
 notify() {
   if [[ -s "${NOTIFICATION_EMAIL}" ]] ; then
-    mail -s "Notification from ReBot" salarcon@opentechinstitute.org \
+    mail -s "Notification from ReBot" alerts@measurementlab.net \
       < ${NOTIFICATION_EMAIL}
   fi
 }


### PR DESCRIPTION
Uses the Google Group alerts@measurementlab.net instead of individual email addresses.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/rebot/4)
<!-- Reviewable:end -->
