### PR TITLE
Adds option to login to Nagios using environment variables, if they exist.

### DIFF
--- a/mlab-ssh-outage.sh
+++ b/mlab-ssh-outage.sh
@@ -70,16 +70,18 @@ find_all_hosts() {
   # Configure a user's login to Nagios.  For more information on netrc files, see
   # the manpage for curl.  If a netrc file doesn't exist, then the user will be
   # prompted to enter credentials.
-  if [ -f ~/.netrc ] && grep -q 'nagios.measurementlab.net' ~/.netrc; then
+  if [[ -n "$NAGIOS_USER" ]] && [[ -n "$NAGIOS_PASS" ]]; then
+    nagios_auth="-u${NAGIOS_USER}:${NAGIOS_PASS}"
+  elif [ -f ~/.netrc ] && grep -q 'nagios.measurementlab.net' ~/.netrc; then
     nagios_auth='--netrc'
   else
     read -p "Nagios login: " nagios_login
     read -s -p "Nagios password: " nagios_pass
-    nagios_auth="--user ${nagios_login}:${nagios_pass}"
+    nagios_auth="-u${nagios_login}:${nagios_pass}"
     echo -e '\n'
   fi
 
-  curl -s "${nagios_auth}" -o "${output_file}" --digest --netrc \
+  curl -s -o "${output_file}" --digest "${nagios_auth}" \
     "http://nagios.measurementlab.net/baseList?show_state=1&service_name="${service_name}"&plugin_output=0&show_problem_acknowledged=1"
 
   # TODO: Make this a unit test

--- a/mlab-ssh-outage.sh
+++ b/mlab-ssh-outage.sh
@@ -29,7 +29,7 @@ NOTIFICATION_EMAIL="${SSH_OUTAGE_TEMP_DIR}/rebot_notify.out"
 REBOOT_ATTEMPTED="${REBOOT_HISTORY_DIR}/reboot_attempted"
 REBOOT_LOG="${REBOOT_HISTORY_DIR}/reboot_log"
 PROBLEMATIC="${REBOOT_HISTORY_DIR}/problematic"
-TOOLS_DIR="/home/salarcon/git/operator/tools"
+TOOLS_DIR="/opt/mlab/operator/tools"
 ########################################
 # Function: fresh_dirs
 # Make a fresh SSH_OUTAGE_TEMP_DIR


### PR DESCRIPTION
This PR adds the ability for `curl` to use Nagios login credentials found in environment variables, if they exists. This will allow us to create a new cron job in /etc/cron.d with the login credentials in env variables declared right in the file rather than in a file in a user's home directory.

For reason that I didn't bother looking into much, I couldn't get `curl` to work with the `--user` option. It kept throwing:

> curl: option --user <someuser>:<somepass>: is unknown

... using the short option `-u` works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/rebot/8)
<!-- Reviewable:end -->
