### PR TITLE
Makes sure that both down hosts files exist before trying to sort and compare them.

### DIFF
--- a/mlab-ssh-outage.sh
+++ b/mlab-ssh-outage.sh
@@ -157,8 +157,10 @@ find_reboot_candidates() {
 
   # If a node's ssh and sshalt statuses are both down, it's a candidate for reboot
   # TODO make ${DOWN_HOSTS_SSH} and ${DOWN_HOSTS_SSHALT} parameters
-  comm -12 <( sort "${DOWN_HOSTS_SSH}") <( sort "${DOWN_HOSTS_SSHALT}" ) > \
-    "${REBOOT_CANDIDATES}"
+  if [[ -f "${DOWN_HOSTS_SSH}" ]] && [[ -f "${DOWN_HOSTS_SSHALT}" ]]; then
+    comm -12 <( sort "${DOWN_HOSTS_SSH}") <( sort "${DOWN_HOSTS_SSHALT}" ) > \
+      "${REBOOT_CANDIDATES}"
+  fi
 
   # TODO: unit test to make sure $REBOOT_CANDIDATES exists
   rm -f "${REBOOT_CANDIDATES}.tmp" && touch "${REBOOT_CANDIDATES}.tmp"


### PR DESCRIPTION
Rebot was throwing a `No such file or directory` error when trying to compare down hosts, since one of the files didn't exist. This PR wraps the comparison in an `if` block to be sure that the files exist before trying to operate on them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/rebot/9)
<!-- Reviewable:end -->
