### PR TITLE
added timestamp to notification email subject line

### DIFF
--- a/mlab-ssh-outage.sh
+++ b/mlab-ssh-outage.sh
@@ -288,7 +288,7 @@ perform_the_reboot() {
 ########################################
 notify() {
   if [[ -s "${NOTIFICATION_EMAIL}" ]] ; then
-    mail -s "Notification from ReBot" alerts@measurementlab.net \
+    mail -s "${TIMESTAMP} - Notification from ReBot" alerts@measurementlab.net \
       < ${NOTIFICATION_EMAIL}
   fi
 }


### PR DESCRIPTION
This commit adds a date time stamp to the rebot email subject line to better separate display of date based threads.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/rebot/10)
<!-- Reviewable:end -->
