### PR TITLE
Take the new service="ssh" (port 22) into account in the offline nodes' query.

### DIFF
--- a/drac_test.sh
+++ b/drac_test.sh
@@ -12,8 +12,8 @@ if [ $# != 2 ] ; then
 fi
 
 # Fail if the machine name starts with mlab4.*
-REGEX_DATE='mlab4.*'
-if [[ $2 =~ $REGEX_DATE ]] ; then
+REGEX_HOST='mlab4.*'
+if [[ $2 =~ $REGEX_HOST ]] ; then
     exit 1;
 fi
 

--- a/drac_test.sh
+++ b/drac_test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# This script replaces drac.py for testing purposes.
+#
+# It takes two arguments and exits with an exit status of 1 if the machine
+# name starts with mlab4.* 
+
+# Make sure there are two arguments
+if [ $# != 2 ] ; then
+    echo $USAGE
+    exit 1;
+fi
+
+# Fail if the machine name starts with mlab4.*
+REGEX_DATE='mlab4.*'
+if [[ $2 =~ $REGEX_DATE ]] ; then
+    exit 1;
+fi
+
+exit 0

--- a/main_test.go
+++ b/main_test.go
@@ -18,6 +18,7 @@ import (
 const (
 	testCredentialsPath = "credentials"
 	testHistoryPath     = "history"
+	testRebootCmd       = "./drac_test.sh"
 )
 
 var (
@@ -442,4 +443,59 @@ func Test_updateHistory(t *testing.T) {
 
 		}
 	})
+}
+
+func Test_rebootOne(t *testing.T) {
+	rebootCmd = testRebootCmd
+	tests := []struct {
+		name     string
+		toReboot string
+		wantErr  bool
+	}{
+		{
+			name:     "success-exit-status-zero",
+			toReboot: "mlab1.lga0t.measurement-lab.org",
+		},
+		{
+			name:     "failure-exit-status-not-zero",
+			toReboot: "mlab4.lga0t.measurement-lab.org",
+			wantErr:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := rebootOne(tt.toReboot); (err != nil) != tt.wantErr {
+				t.Errorf("rebootOne() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_rebootMany(t *testing.T) {
+	rebootCmd = testRebootCmd
+
+	toReboot := []string{
+		"mlab1.lga0t.measurement-lab.org",
+		"mlab2.lga0t.measurement-lab.org",
+	}
+	want := map[string]error{}
+
+	t.Run("success-all-machines-rebooted", func(t *testing.T) {
+		if got := rebootMany(toReboot); !reflect.DeepEqual(got, want) {
+			t.Errorf("rebootMany() = %v, want %v", got, want)
+		}
+	})
+
+	// mlab4.* machines always returns a non-zero exit code in drac_test.sh.
+	toReboot = []string{
+		"mlab4.lga0t.measurement-lab.org",
+	}
+
+	t.Run("failure-exit-code-non-zero", func(t *testing.T) {
+		got := rebootMany(toReboot)
+		if err, ok := got["mlab4.lga0t.measurement-lab.org"]; !ok || err == nil {
+			t.Errorf("rebootMany() = %v, key not in map or err == nil", got)
+		}
+	})
+
 }

--- a/main_test.go
+++ b/main_test.go
@@ -387,27 +387,18 @@ func Test_main(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		main()
 	})
-
+	prom = nil
 }
 
 func Test_initPrometheusClient(t *testing.T) {
-	tests := []struct {
-		name string
-	}{
-		{
-			name: "success",
-		},
-	}
 
 	setupCredentials()
 	defer removeFiles(testCredentialsPath)
 
 	credentialsPath = testCredentialsPath
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			initPrometheusClient()
-		})
-	}
+	t.Run("success", func(t *testing.T) {
+		initPrometheusClient()
+	})
 }
 
 func cloneHistory(h map[string]candidate) map[string]candidate {


### PR DESCRIPTION
This allows to monitor the new k8s infrastructure as well, as SSH is running on port 22 there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/rebot/12)
<!-- Reviewable:end -->
