### PR TITLE
Fix healthcheck query to correctly monitor CoreOS nodes.

### DIFF
--- a/healthcheck/prometheus.go
+++ b/healthcheck/prometheus.go
@@ -21,6 +21,7 @@ var (
 			unless on(site) gmx_site_maintenance == 1
 			unless on (machine) lame_duck_node == 1
 			unless on (machine) count_over_time(probe_success{service="ssh", module="ssh_v4_online"}[%[1]dm]) < 14
+			unless on (machine) rate(inotify_extension_create_total{ext=".s2c_snaplog"}[%[1]dm]) > 0
 			unless on (machine) increase(ndt_test_total[%[1]dm]) > 0`
 
 	// SwitchQuery is a prometheus query to determine what switches are

--- a/healthcheck/prometheus.go
+++ b/healthcheck/prometheus.go
@@ -18,7 +18,7 @@ var (
 			unless on(site) gmx_site_maintenance == 1
 			unless on (machine) lame_duck_node == 1
 			unless on (machine) count_over_time(probe_success{service="ssh", module="ssh_v4_online"}[%[1]dm]) < 14
-			unless on (machine) rate(ndt_test_total[%[1]dm]) > 0`
+			unless on (machine) increase(ndt_test_total[%[1]dm]) > 0`
 
 	// SwitchQuery is a prometheus query to determine what switches are
 	// offline.  To determine if a switch is offline, pings are generally

--- a/healthcheck/prometheus.go
+++ b/healthcheck/prometheus.go
@@ -12,16 +12,13 @@ import (
 )
 
 var (
-	NodeQuery = `(label_replace(sum_over_time(probe_success{service="ssh806", module="ssh_v4_online"}[%[1]dm]) == 0,
+	NodeQuery = `label_replace(sum_over_time(probe_success{service="ssh", module="ssh_v4_online"}[%[1]dm]) == 0,
 	"site", "$1", "machine", ".+?\\.(.+?)\\..+")
-	unless on (machine)
-	label_replace(sum_over_time(probe_success{service="ssh", module="ssh_v4_online"}[%[1]dm]) > 0,
-	"site", "$1", "machine", ".+?\\.(.+?)\\..+"))
 			unless on(machine) gmx_machine_maintenance == 1
 			unless on(site) gmx_site_maintenance == 1
 			unless on (machine) lame_duck_node == 1
 			unless on (machine) count_over_time(probe_success{service="ssh806", module="ssh_v4_online"}[%[1]dm]) < 14
-			unless on (machine) rate(inotify_extension_create_total{ext=".s2c_snaplog"}[%[1]dm]) > 0`
+			unless on (machine) rate(ndt_test_total[%[1]dm]) > 0`
 
 	// SwitchQuery is a prometheus query to determine what switches are
 	// offline.  To determine if a switch is offline, pings are generally

--- a/healthcheck/prometheus.go
+++ b/healthcheck/prometheus.go
@@ -14,6 +14,9 @@ import (
 var (
 	NodeQuery = `label_replace(sum_over_time(probe_success{service="ssh", module="ssh_v4_online"}[%[1]dm]) == 0,
 	"site", "$1", "machine", ".+?\\.(.+?)\\..+")
+			unless on (machine)
+				label_replace(sum_over_time(probe_success{service="ssh806", module="ssh_v4_online"}[%[1]dm]) > 0,
+        			"site", "$1", "machine", ".+?\\.(.+?)\\..+")
 			unless on(machine) gmx_machine_maintenance == 1
 			unless on(site) gmx_site_maintenance == 1
 			unless on (machine) lame_duck_node == 1

--- a/healthcheck/prometheus.go
+++ b/healthcheck/prometheus.go
@@ -17,7 +17,7 @@ var (
 			unless on(machine) gmx_machine_maintenance == 1
 			unless on(site) gmx_site_maintenance == 1
 			unless on (machine) lame_duck_node == 1
-			unless on (machine) count_over_time(probe_success{service="ssh806", module="ssh_v4_online"}[%[1]dm]) < 14
+			unless on (machine) count_over_time(probe_success{service="ssh", module="ssh_v4_online"}[%[1]dm]) < 14
 			unless on (machine) rate(ndt_test_total[%[1]dm]) > 0`
 
 	// SwitchQuery is a prometheus query to determine what switches are


### PR DESCRIPTION
This is needed as criteria for monitoring CoreOS nodes are different.

Changes:
- Check only service="ssh" (port 22)
- "rate(ndt_test_total[15m]) > 0" is used instead of file creation rate

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/rebot/24)
<!-- Reviewable:end -->
