### PR TITLE
Change healthcheck query to use the "site" label

### DIFF
--- a/healthcheck/prometheus.go
+++ b/healthcheck/prometheus.go
@@ -17,11 +17,9 @@ var (
 	// based on gmx maintenance, lame-duck mode, or the presence of recent NDT
 	// tests on the node is applied. This makes sure we never reboot a node
 	// unnecessarily or lose data.
-	NodeQuery = `label_replace(sum_over_time(probe_success{service="ssh", module="ssh_v4_online"}[%[1]dm]) == 0,
-	"site", "$1", "machine", ".+?\\.(.+?)\\..+")
+	NodeQuery = `sum_over_time(probe_success{service="ssh", module="ssh_v4_online"}[%[1]dm]) == 0
 			unless on (machine)
-				label_replace(sum_over_time(probe_success{service="ssh806", module="ssh_v4_online"}[%[1]dm]) > 0,
-        			"site", "$1", "machine", ".+?\\.(.+?)\\..+")
+				sum_over_time(probe_success{service="ssh806", module="ssh_v4_online"}[%[1]dm]) > 0
 			unless on(machine) gmx_machine_maintenance == 1
 			unless on(site) gmx_site_maintenance == 1
 			unless on (machine) lame_duck_node == 1

--- a/promtest/prometheus_testing.go
+++ b/promtest/prometheus_testing.go
@@ -7,12 +7,13 @@ import (
 	"errors"
 	"time"
 
+	"github.com/prometheus/client_golang/api"
 	"github.com/prometheus/common/model"
 )
 
 // PromClient is Prometheus HTTP client's interface
 type PromClient interface {
-	Query(context.Context, string, time.Time) (model.Value, error)
+	Query(context.Context, string, time.Time) (model.Value, api.Error)
 }
 
 // PrometheusMockClient is a test client that returns fake values only for a
@@ -24,7 +25,7 @@ type PrometheusMockClient struct {
 
 type response struct {
 	value model.Value
-	err   error
+	err   api.Error
 }
 
 // NewPrometheusMockClient creates a mock client to test Prometheus queries.
@@ -35,7 +36,7 @@ func NewPrometheusMockClient() *PrometheusMockClient {
 }
 
 // Register maps a query to the expected model.Value that must be returned.
-func (p *PrometheusMockClient) Register(q string, resp model.Value, err error) {
+func (p *PrometheusMockClient) Register(q string, resp model.Value, err api.Error) {
 	p.responses[q] = response{
 		value: resp,
 		err:   err,
@@ -73,12 +74,12 @@ func CreateSample(labels map[string]string, value float64, t model.Time) *model.
 
 // Query is a mock implementation that returns the model.Value corresponding
 // to the query, if any, or an error.
-func (p PrometheusMockClient) Query(ctx context.Context, q string, t time.Time) (model.Value, error) {
+func (p PrometheusMockClient) Query(ctx context.Context, q string, t time.Time) (model.Value, api.Error) {
 	resp, ok := p.responses[q]
 
 	if ok {
-		return resp.value, resp.err
+		return resp.value, nil
 	}
 
-	return nil, errors.New("Undefined query: " + q)
+	return nil, api.NewErrorAPI(errors.New("Undefined query: "+q), []string{})
 }


### PR DESCRIPTION
Now that we have the "site" label on all the blackbox-exporter targets, we can avoid using label_replace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/rebot/29)
<!-- Reviewable:end -->
