### PR TITLE
Make rebot buildable again.

### DIFF
--- a/promtest/prometheus_testing_test.go
+++ b/promtest/prometheus_testing_test.go
@@ -69,7 +69,7 @@ func TestPrometheusMockClient_Query(t *testing.T) {
 				responses: tt.responses,
 			}
 
-			got, err := p.Query(tt.args.ctx, tt.args.q, tt.args.t)
+			got, _, err := p.Query(tt.args.ctx, tt.args.q, tt.args.t)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("PrometheusMockClient.Query() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION

Some things have changed in the Prometheus client API. Specifically:
- Query() does not return an api.Error anymore, but a Go error
- Query() also returns a v1.Warnings for non-critical warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/rebot/32)
<!-- Reviewable:end -->
