### PR TITLE
Update Prometheus URL to -basicauth

### DIFF
--- a/main.go
+++ b/main.go
@@ -165,7 +165,7 @@ func initPrometheusClient() {
 	if prom == nil {
 		config := api.Config{
 			Address: "https://" + promUsername + ":" + promPassword +
-				"@prometheus." + project + ".measurementlab.net",
+				"@prometheus-basicauth." + project + ".measurementlab.net",
 		}
 
 		client, err := api.NewClient(config)


### PR DESCRIPTION
We recently moved the HTTP basic auth URL for Prometheus to `prometheus-basicauth.$PROJECT.measurementlab.net`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/rebot/34)
<!-- Reviewable:end -->
